### PR TITLE
Support the new call syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^7.2.5",
         "illuminate/notifications": "^7.0",
         "illuminate/support": "^7.0",
+        "nexmo/client-core": "^2.2",
         "nexmo/laravel": "^2.0"
     },
     "require-dev": {

--- a/src/NexmoVoiceChannel.php
+++ b/src/NexmoVoiceChannel.php
@@ -5,6 +5,10 @@ namespace Roomies\NexmoVoiceChannel;
 use App\User;
 use Illuminate\Notifications\Notification;
 use Nexmo\Client;
+use Nexmo\Voice\Endpoint\Phone;
+use Nexmo\Voice\NCCO\Action\Talk;
+use Nexmo\Voice\NCCO\NCCO;
+use Nexmo\Voice\OutboundCall;
 
 class NexmoVoiceChannel
 {
@@ -71,23 +75,15 @@ class NexmoVoiceChannel
      */
     protected function call($phoneNumber, $message)
     {
-        $this->client->calls()->create([
-            'to' => [[
-                'type' => 'phone',
-                'number' => $phoneNumber,
-            ]],
-            'from' => [
-                'type' => 'phone',
-                'number' => $this->from,
-            ],
-            'ncco' => [
-                [
-                    'action' => 'talk',
-                    'text' => $message,
-                    'level' => 1,
-                    'voiceName' => $this->voice,
-                ]
-            ]
-        ]);
+        $outboundCall = new OutboundCall(new Phone($phoneNumber), new Phone($this->from));
+
+        $ncco = (new NCCO)->addAction(Talk::factory($message, [
+            'level' => 1,
+            'voiceName' => $this->voice,
+        ]));
+
+        $outboundCall->setNCCO($ncco);
+
+        $this->client->voice()->createOutboundCall($outboundCall);
     }
 }

--- a/tests/NexmoVoiceChannelTest.php
+++ b/tests/NexmoVoiceChannelTest.php
@@ -4,8 +4,10 @@ namespace Roomies\NexmoVoiceChannel\Tests;
 
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Arr;
 use Mockery;
 use Nexmo\Client;
+use Nexmo\Voice\OutboundCall;
 use Roomies\NexmoVoiceChannel\Markup\Message;
 use Roomies\NexmoVoiceChannel\Markup\Sentence;
 use Roomies\NexmoVoiceChannel\NexmoVoiceChannel;
@@ -19,25 +21,19 @@ class NexmoVoiceChannelTest extends TestCase
 
         $channel = new NexmoVoiceChannel($nexmo = Mockery::mock(Client::class), '4444444444', 'Kimberly');
 
-        $nexmo->shouldReceive('calls->create')
-            ->with([
-                'to' => [[
-                    'type' => 'phone',
-                    'number' => '5555555555',
-                ]],
-                'from' => [
-                    'type' => 'phone',
-                    'number' => '4444444444'
-                ],
-                'ncco' => [
-                    [
-                        'action' => 'talk',
-                        'text' => '<speak><s>Hello, world</s></speak>',
-                        'level' => 1,
-                        'voiceName' => 'Kimberly'
-                    ]
-                ]
-            ])->once();
+        $nexmo->shouldReceive('voice->createOutboundCall')
+            ->with(Mockery::on(function ($outboundCall) {
+                $ncco = Arr::first($outboundCall->getNCCO()->toArray());
+
+                return $outboundCall instanceof OutboundCall
+                    && Arr::get($outboundCall->getTo()->toArray(), 'number') === '5555555555'
+                    && Arr::get($outboundCall->getFrom()->toArray(), 'number') === '4444444444'
+                    && Arr::get($ncco, 'action') === 'talk'
+                    && Arr::get($ncco, 'text') === '<speak><s>Hello, world</s></speak>'
+                    && Arr::get($ncco, 'level') === '1'
+                    && Arr::get($ncco, 'voiceName') === 'Kimberly';
+            }))
+            ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -49,25 +45,19 @@ class NexmoVoiceChannelTest extends TestCase
 
         $channel = new NexmoVoiceChannel($nexmo = Mockery::mock(Client::class), '4444444444', 'Kimberly');
 
-        $nexmo->shouldReceive('calls->create')
-            ->with([
-                'to' => [[
-                    'type' => 'phone',
-                    'number' => '5555555555',
-                ]],
-                'from' => [
-                    'type' => 'phone',
-                    'number' => '4444444444'
-                ],
-                'ncco' => [
-                    [
-                        'action' => 'talk',
-                        'text' => '<speak><s>Hello, world</s></speak>',
-                        'level' => 1,
-                        'voiceName' => 'Kimberly'
-                    ]
-                ]
-            ])->once();
+        $nexmo->shouldReceive('voice->createOutboundCall')
+            ->with(Mockery::on(function ($outboundCall) {
+                $ncco = Arr::first($outboundCall->getNCCO()->toArray());
+
+                return $outboundCall instanceof OutboundCall
+                    && Arr::get($outboundCall->getTo()->toArray(), 'number') === '5555555555'
+                    && Arr::get($outboundCall->getFrom()->toArray(), 'number') === '4444444444'
+                    && Arr::get($ncco, 'action') === 'talk'
+                    && Arr::get($ncco, 'text') === '<speak><s>Hello, world</s></speak>'
+                    && Arr::get($ncco, 'level') === '1'
+                    && Arr::get($ncco, 'voiceName') === 'Kimberly';
+            }))
+            ->once();
 
         $channel->send($notifiable, $notification);
     }


### PR DESCRIPTION
The latest version of Nexmo (2.2+) has changed the syntax for shortcodes and voice calls.

I've PR'd the changes to Laravel's Nexmo channel to fix shortcodes, this PR has the changes required for voice calls.

Tests are a little uglier but the implementation does feel a little better.