### PR TITLE
feat: return api response to be consumed by event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vonage-voice-channel
+# Vonage Voice Notification Channel for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/roomies/vonage-voice-channel.svg)](https://packagist.org/packages/roomies/vonage-voice-channel)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/roomies-com/vonage-voice-channel/phpunit.yml?branch=master)

--- a/src/VonageVoiceChannel.php
+++ b/src/VonageVoiceChannel.php
@@ -61,7 +61,7 @@ class VonageVoiceChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return void
+     * @return void|\Vonage\Voice\Webhook\Event
      */
     public function send($notifiable, Notification $notification)
     {
@@ -71,7 +71,7 @@ class VonageVoiceChannel
 
         $message = $notification->toVoice($notifiable);
 
-        $this->call($to, (string) $message);
+        return $this->call($to, (string) $message);
     }
 
     /**
@@ -79,7 +79,7 @@ class VonageVoiceChannel
      *
      * @param  string  $phoneNumber
      * @param  string  $message
-     * @return void
+     * @return \Vonage\Voice\Webhook\Event
      */
     protected function call($phoneNumber, $message)
     {
@@ -93,6 +93,6 @@ class VonageVoiceChannel
 
         $outboundCall->setNCCO($ncco);
 
-        $this->client->voice()->createOutboundCall($outboundCall);
+        return $this->client->voice()->createOutboundCall($outboundCall);
     }
 }


### PR DESCRIPTION
Hi,

The channel should return the api response so that it can be consumed by the Event Listeners.

Here is an example:

```php
// EventServiceProvider.php


protected $listen = [
    NotificationSent::class => [
        VoiceCallSentNotificationListener::class,
    ],
];
```


```php
// VoiceCallSentNotificationListener.php

public function handle(NotificationSent $event)
{
    // $event->channel // voice
    // $event->notifiable
    // $event->notification
    // $event->response // api response from vonage
}
```

These changes should not break anything.

You can read about it here

https://laravel.com/docs/9.x/notifications#notification-events